### PR TITLE
chore(datetime): Support unmashal of datetime attributes

### DIFF
--- a/custom_types.go
+++ b/custom_types.go
@@ -37,12 +37,7 @@ func (f *FlexibleFloat) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 
 type Time time.Time
 
-func (t *Time) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	var dateStr string
-	if err := d.DecodeElement(&dateStr, &start); err != nil {
-		return err
-	}
-
+func (t *Time) parseTimeString(dateStr string) error {
 	// Trim any whitespace
 	dateStr = strings.TrimSpace(dateStr)
 
@@ -71,4 +66,16 @@ func (t *Time) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 
 	*t = Time(parsedTime)
 	return nil
+}
+
+func (t *Time) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var dateStr string
+	if err := d.DecodeElement(&dateStr, &start); err != nil {
+		return err
+	}
+	return t.parseTimeString(dateStr)
+}
+
+func (t *Time) UnmarshalXMLAttr(attr xml.Attr) error {
+	return t.parseTimeString(attr.Value)
 }

--- a/uddf_test.go
+++ b/uddf_test.go
@@ -147,3 +147,27 @@ func TestTimeUnmarshalXML(t *testing.T) {
 		})
 	}
 }
+
+func TestDateOfTripXML(t *testing.T) {
+	xmlData := `<dateoftrip startdate="2003-04-12" enddate="2003-04-19"/>`
+	
+	var dateOfTrip DateOfTrip
+	err := xml.Unmarshal([]byte(xmlData), &dateOfTrip)
+	if err != nil {
+		t.Fatalf("failed to unmarshal XML: %v", err)
+	}
+
+	expectedStart := time.Date(2003, 4, 12, 0, 0, 0, 0, time.UTC)
+	expectedEnd := time.Date(2003, 4, 19, 0, 0, 0, 0, time.UTC)
+
+	actualStart := time.Time(dateOfTrip.StartDate)
+	actualEnd := time.Time(dateOfTrip.EndDate)
+
+	if !actualStart.Equal(expectedStart) {
+		t.Errorf("expected start date %v, got %v", expectedStart, actualStart)
+	}
+
+	if !actualEnd.Equal(expectedEnd) {
+		t.Errorf("expected end date %v, got %v", expectedEnd, actualEnd)
+	}
+}


### PR DESCRIPTION
Now supports ` <dateoftrip startdate="2003-04-12" enddate="2003-04-19"/>`